### PR TITLE
Hide Ruby native code representation

### DIFF
--- a/fr
+++ b/fr
@@ -23,8 +23,8 @@ def run_eval(fun, programs)
   body = fun.body
 
   case body
-  when Proc
-    body.call([base,env], fun)
+  when NativeRubyCode
+    body.body.call([base,env], fun)
   when NumberType
     body
   when StringType

--- a/lib/defs.rb
+++ b/lib/defs.rb
@@ -49,9 +49,9 @@ class FunBody < Struct.new(:body)
   end
 end
 
-class Proc
+class NativeRubyCode < Struct.new(:name, :body, :domains)
   def to_s
-    "<native_rb>"
+    "#<native(#{name} :: #{domains.to_s}>"
   end
 end
 

--- a/lib/parser.y
+++ b/lib/parser.y
@@ -21,7 +21,7 @@ rule
 
   domains: domain {  result = val.flatten }
          | domains ARROW domain {  result = [result, val[2]].flatten }
-         | { binding.pry; result = [] }
+         | { result = [] }
 
   domain: TYPE
 
@@ -94,6 +94,4 @@ end
     @q.shift
   end
 
-#
 ---- footer
-

--- a/lib/prelude.rb
+++ b/lib/prelude.rb
@@ -1,34 +1,32 @@
 module Prelude
   def apply(program)
     program + [
-      Add,
-      Sub,
-      Mul,
-      Div
+      BinOp["add", ->(x, y) { x + y } ],
+      BinOp["sub", ->(x, y) { x - y } ],
+      BinOp["mul", ->(x, y) { x * y } ],
+      BinOp["div", ->(x, y) { x / y } ]
     ]
   end
   module_function :apply
 
   BinOp = ->(name, ruby_func) do
     id_x, id_y = Identifier.new("x"), Identifier.new("y")
+    int_type = Domain.new(NumberType)
     FunDef.new(
       Identifier.new(name),
       FunCallArgs.new([id_x, id_y]),
-      ->(programs, current_function) do
-        program, env = programs
-        finder = ->(id) { [program,env].flatten.find { |a| a.identifier == id } }
-        fun_x, fun_y = finder[id_x], finder[id_y]
-        x = run_eval(fun_x, programs)
-        y = run_eval(fun_y, programs)
-        ruby_func[x, y]
-      end).tap do |fd|
-        int = Domain.new(NumberType)
-        fd.domains = Domains.new([int, int, int])
-      end
+      NativeRubyCode.new(
+        name,
+        ->(programs, current_function) do
+          program, env = programs
+          finder = ->(id) { [program,env].flatten.find { |a| a.identifier == id } }
+          fun_x, fun_y = finder[id_x], finder[id_y]
+          x = run_eval(fun_x, programs)
+          y = run_eval(fun_y, programs)
+          ruby_func[x, y]
+        end,
+        Domains.new([int_type, int_type, int_type])
+      ),
+      Domains.new([int_type, int_type, int_type]))
   end
-
-  Add = BinOp["add", ->(x, y) { x + y } ]
-  Sub = BinOp["sub", ->(x, y) { x - y } ]
-  Mul = BinOp["mul", ->(x, y) { x * y } ]
-  Div = BinOp["div", ->(x, y) { x / y } ]
 end


### PR DESCRIPTION
It is highly inconvenient to use a `Proc` here as all other `FunDef`s get a body initialized with a wrapper object. This PR adds a new class, `RubyNativeCode`, that wraps actual Ruby `Proc` so we can use the same computation logic downstream.